### PR TITLE
Added public function getMessages()

### DIFF
--- a/phpws/websocket.client.php
+++ b/phpws/websocket.client.php
@@ -137,6 +137,10 @@ class WebSocket implements WebSocketObserver
 
         return true;
     }
+    
+    public function getMessages() { //sfranzyshen
+        return count($this->_messages);
+    }
 
     public function getTimeOut()
     {


### PR DESCRIPTION
Added the public function getMessages() so that one can test the status of the _messages array without the need to call the readMessage() function (blocking loop).

Instead of:

// Wait for an incoming message
$msg = $client->readMessage(); // blocking loop

New usage:

if($client->getMessages()) // non-blocking
___$msg = $client->readMessage();
