### PR TITLE
Fix for incomplete handshake header

### DIFF
--- a/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php
+++ b/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php
@@ -87,10 +87,19 @@ class WebSocketTransportHybi extends WebSocketTransport
         return base64_encode(sha1($challenge . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', true));
     }
 
+	private static function isValidHeader($data) {
+		return substr($data,-4) == "\x0d\x0a\x0d\x0a";
+	}
+
     public function handleData(&$data)
     {
         if(!$this->connected)
+		{
+			if (!$this->isValidHeader($data)) {
+				return array();
+			}
             $data = $this->readHandshakeResponse($data);
+		}
 
         $frames = array();
         while ($frame = WebSocketFrame::decode($data)){


### PR DESCRIPTION
When starting up a Client, the first packet of data received is expected to be a complete header, and no validation of it is performed even for RFC6455 required elements.  This addition insures that the entire header has arrived before marking the websocket transport as connected, instead of allowing the late arriving header data to remain in the data stream, resulting in framing synchronization problems and lost data.
