### PR TITLE
Fix for secure connections

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -92,7 +92,7 @@ class WebSocket extends EventEmitter
         $deferred = new Deferred();
 
         $connector->create($uri->getHost(), $uri->getPort() ?: $defaultPort)
-            ->then(function (\React\Stream\Stream $stream) use ($that, $uri, $deferred, $timeOut){
+            ->then(function (\React\Stream\DuplexStreamInterface $stream) use ($that, $uri, $deferred, $timeOut){
 
                 if($timeOut){
                     $timeOutTimer = $that->loop->addTimer($timeOut, function() use($promise, $stream, $that){


### PR DESCRIPTION
React\SocketClient\SecureStream does not extend React\Stream\Stream, so this code won't work with secure connections. It should instead look for the interface that both implement.