### PR TITLE
Provide reject() for WebSocket consumers in case of connection failure

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -141,8 +141,9 @@ class WebSocket extends EventEmitter
 
                 $transport->initiateHandshake($uri);
                 $that->state = WebSocket::STATE_HANDSHAKE_SENT;
-            }, function($reason) use ($that)
+            }, function($reason) use ($that, $deferred)
             {
+                $deferred->reject($reason);
                 $that->logger->err($reason);
             });
 


### PR DESCRIPTION
Give a chance for consumers to properly react to the issue e.g.  "Connection refused" error