### PR TITLE
Catch exception thrown in stream_socket_accept when using secure cont…

### DIFF
--- a/src/Devristo/Phpws/Server/WebSocketServer.php
+++ b/src/Devristo/Phpws/Server/WebSocketServer.php
@@ -121,7 +121,12 @@ class WebSocketServer extends EventEmitter
         $logger = $this->_logger;
 
         $this->loop->addReadStream($serverSocket, function ($serverSocket) use ($that, $logger, $sockets) {
-            $newSocket = stream_socket_accept($serverSocket);
+            try
+            {
+                $newSocket = stream_socket_accept($serverSocket);
+            } catch (\ErrorException $e) {
+                $newSocket = false;
+            }
 
             if (false === $newSocket) {
                 return;


### PR DESCRIPTION
Catch exception thrown in stream_socket_accept when using secure contexts, and the connecting client does not perform the SSL handshake correctly.
