### PR TITLE
Pull in upstream fix for PHP hostname and SSL when creating new socket

### DIFF
--- a/src/Devristo/Phpws/Client/Connector.php
+++ b/src/Devristo/Phpws/Client/Connector.php
@@ -9,27 +9,31 @@ use React\Promise\When;
 
 class Connector extends BaseConnector
 {
-    
     protected $contextOptions = array();
-    
-    public function __construct(LoopInterface $loop, Resolver $resolver, array $contextOptions = null) 
+
+    public function __construct(LoopInterface $loop, Resolver $resolver, array $contextOptions = null)
     {
         parent::__construct($loop, $resolver);
-        
+
         $contextOptions = null === $contextOptions ? array() : $contextOptions;
         $this->contextOptions = $contextOptions;
     }
-    
-    protected function createStreamContext() 
-    {
-        return stream_context_create($this->contextOptions);
-    }
-    
+
     public function createSocketForAddress($address, $port, $hostName = null)
     {
         $url = $this->getSocketUrl($address, $port);
 
-        $socket = stream_socket_client($url, $errno, $errstr, 0, STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT, $this->createStreamContext());
+        $contextOpts = $this->contextOptions;
+        // Fix for SSL in PHP >= 5.6, where peer name must be validated.
+        if ($hostName !== null) {
+            $contextOpts['ssl']['SNI_enabled'] = true;
+            $contextOpts['ssl']['SNI_server_name'] = $hostName;
+            $contextOpts['ssl']['peer_name'] = $hostName;
+        }
+
+        $flags = STREAM_CLIENT_CONNECT | STREAM_CLIENT_ASYNC_CONNECT;
+        $context = stream_context_create($contextOpts);
+        $socket = stream_socket_client($url, $errno, $errstr, 0, $flags, $context);
 
         if (!$socket) {
             return When::reject(new \RuntimeException(
@@ -46,6 +50,5 @@ class Connector extends BaseConnector
             ->waitForStreamOnce($socket)
             ->then(array($this, 'checkConnectedSocket'))
             ->then(array($this, 'handleConnectedSocket'));
-    }    
-    
+    }
 }


### PR DESCRIPTION
PHP 5.6 has a few changes on how SSL is handled; hostnames are now verified during the SSL handshake. This issue was already fixed in react/socket-client [here](https://github.com/reactphp/socket-client/pull/23), but the changes didn't cascade since the changed method is overriden in `Devristo\Phpws\Client\Connector`. This should fix #60 (and maybe other SSL-related bugs).