### PR TITLE
Allow another DNS server to be used. Useful when locked behind corporate network that disallows outbound DNS requests.

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -68,7 +68,8 @@ class WebSocket extends EventEmitter
             throw new WebSocketInvalidUrlScheme();
 
         $dnsResolverFactory = new \React\Dns\Resolver\Factory();
-        $this->dns = $dnsResolverFactory->createCached('8.8.8.8', $loop);
+        $server = false === getenv('DNS_SERVER') ? '8.8.8.8' : getenv('DNS_SERVER');
+        $this->dns = $dnsResolverFactory->createCached($server, $loop);
     }
 
     public function open($timeOut=null)


### PR DESCRIPTION
Pull DNS server from env variable. Fallback to google public DNS if not set.
