### PR TITLE
PHP7 compatible frame decoding

### DIFF
--- a/src/Devristo/Phpws/Framing/WebSocketFrame.php
+++ b/src/Devristo/Phpws/Framing/WebSocketFrame.php
@@ -137,7 +137,8 @@ class WebSocketFrame implements WebSocketFrameInterface
         $frame = new self();
 
         // Read the first two bytes, then chop them off
-        list($firstByte, $secondByte) = substr($buffer, 0, 2);
+        $firstByte = substr($buffer, 0, 1);
+        $secondByte = substr($buffer, 1, 1);
         $raw = substr($buffer, 2);
 
         $firstByte = ord($firstByte);


### PR DESCRIPTION
List does not support unpacking in PHP7.

http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.list.string