### PR TITLE
Add close emitter.

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -109,9 +109,9 @@ class WebSocket extends EventEmitter
                 $that->stream = $stream;
 
                 $stream->on("close", function() use($that){
-                    $that->emit('close');
                     $that->isClosing = false;
                     $that->state = WebSocket::STATE_CLOSED;
+                    $that->emit('close');
                 });
 
                 // Give the chance to change request

--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -109,6 +109,7 @@ class WebSocket extends EventEmitter
                 $that->stream = $stream;
 
                 $stream->on("close", function() use($that){
+                    $that->emit('close');
                     $that->isClosing = false;
                     $that->state = WebSocket::STATE_CLOSED;
                 });


### PR DESCRIPTION
In my application of the WebSocket client, I want to be able to re-open the connection if it has been accidentally closed by the server (lost connection temporarily or something similar). I noticed the stream close emitter is being used, but it's not being forwarded.

I just added a line that forwards the close emission so that clients can detect when the connection has been closed.

#58 references something similar, but I'm not for sure why the issue was closed (or if it has to do with the client implementation).