### PR TITLE
Add a getState function on Websocket client

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -188,4 +188,9 @@ class WebSocket extends EventEmitter
                 $loop->cancelTimer($closeTimer);
         });
     }
+
+    public function getState()
+    {
+        return $this->state;
+    }
 }


### PR DESCRIPTION
The class manages a state of the connection but never use it. Some time we want to know the state of an instance.