### PR TITLE
Fix for rand parameter

### DIFF
--- a/src/Devristo/Phpws/Framing/WebSocketFrame.php
+++ b/src/Devristo/Phpws/Framing/WebSocketFrame.php
@@ -119,7 +119,7 @@ class WebSocketFrame implements WebSocketFrameInterface
 
         $key = 0;
         if ($this->mask) {
-            $key = pack("N", rand(0, pow(255, 4) - 1));
+            $key = pack("N", rand(0, PHP_INT_MAX));
             $encoded .= $key;
         }
 


### PR DESCRIPTION
Fix for PHP Warning on 32 bit.
```php
<?php
var_dump(pow(255, 4) - 1);
// float(4228250624)

rand(0, pow(255, 4) - 1);
// PHP Warning:  rand() expects parameter 2 to be integer, float given
```
