### PR TITLE
composer update for compat with php 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     },
     "require": {
-        "zendframework/zend-log": "2.*",
+        "zendframework/zend-stdlib": "3.0.*",
+        "zendframework/zend-log": "2.8.*",
         "react/socket": "0.4.*",
         "react/stream": "0.4.*",
         "react/socket-client": "0.4.*",


### PR DESCRIPTION
from https://packagist.org/packages/zendframework/zend-log#2.9.1

2.9 zend requires 5.6 | 5.7, and does not work with 5.5, which is advertised on the documentation of the lib (Actually, documentation even advertises compat with 5.4). 

so except if there is really feature of zend 2.9.* used, we should require 2.8.* in composer.

