### PR TITLE
Receive server pong by client ping

### DIFF
--- a/src/Devristo/Phpws/Client/WebSocket.php
+++ b/src/Devristo/Phpws/Client/WebSocket.php
@@ -141,6 +141,10 @@ class WebSocket extends EventEmitter
                     $that->emit("message", array("message" => $message));
                 });
 
+                $transport->on("pong", function($frame) use($that){
+                    $that->emit("pong", array("frame" => $frame));
+                });
+
                 $transport->initiateHandshake($uri);
                 $that->state = WebSocket::STATE_HANDSHAKE_SENT;
             }, function($reason) use ($that, $deferred)

--- a/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php
+++ b/src/Devristo/Phpws/Protocol/WebSocketTransportHybi.php
@@ -173,7 +173,14 @@ class WebSocketTransportHybi extends WebSocketTransport
                 $frame = WebSocketFrame::create(WebSocketOpcode::PongFrame, $frame->getData());
                 $this->sendFrame($frame);
                 break;
+            case WebSocketOpcode::PongFrame :
+                $this->receivePongFrame($frame);
+                break;
         }
+    }
+
+    public function receivePongFrame($frame) {
+        $this->emit("pong",  array($frame));
     }
 
     public function sendString($msg)


### PR DESCRIPTION
Hello! First of all, tnx for Merged #95

I want to share my idea of improving the library.

The best way to check socket status(check server alive) - send clients ping:

$loop->addPeriodicTimer(mc::socketCheckInterval, function() use($client, $logger){
    $frame = WebSocketFrame::create(WebSocketOpcode::PingFrame);
    $client->sendFrame($frame);
    $logger->notice("ping");

    //DO SOMETHING
});

And receive server pong:
$client->on("pong", function($frame) use ($logger, $client){
    $logger->notice('pong');

    //DO SOMETHING
});

Also, it is very important sometimes to look at the server's response:
$client->on("pong", function($frame) use ($logger, $client){
    $logger->notice('pong');

   var_dump($frame->getData());
   var_dump($frame);
});

Maybe my suggestion needs to be improved or changed, but in the simplest form, PONG is needed